### PR TITLE
Update PropelQueryBuilderDataSource.php

### DIFF
--- a/Table/DataSource/PropelQueryBuilderDataSource.php
+++ b/Table/DataSource/PropelQueryBuilderDataSource.php
@@ -130,7 +130,7 @@ class PropelQueryBuilderDataSource implements DataSourceInterface
     {
         if ($order !== null) {
             $useCount = 0;
-            $column = $order->getCurrentColumnName();
+            $orderColumn = $order->getCurrentColumnName();
             if(strpos($order->getCurrentColumnName(),'.') !== false) {
                 $explodedOrder = explode('.',$order->getCurrentColumnName());
                 for($i = 0; $i < sizeof($explodedOrder)-1;$i++) {
@@ -138,9 +138,10 @@ class PropelQueryBuilderDataSource implements DataSourceInterface
                     $query = $query->$use();
                     $useCount++;
                 }
-                $column = end($explodedOrder);
+                $orderColumn = $explodedOrder[sizeof($explodedOrder)-1];
             }
-            $query = $query->orderBy($column, strtoupper($order->getCurrentDirection()));
+            $orderBy = 'orderBy'.ucfirst($orderColumn);
+            $query = $query->$orderBy(strtoupper($order->getCurrentDirection()));
             for($i = 0; $i < $useCount; $i++) {
                 $query = $query->endUse();
             }


### PR DESCRIPTION
With this change it is possible to use own written orderBy Methods in Propel and the name of the column that we want order don't need to be the name of the column. So it can be an combination order from diffrent tables, etc.